### PR TITLE
Add Notification Preferences to User Schema and Implement Related Endpoints

### DIFF
--- a/controllers/user/auth.controllers.js
+++ b/controllers/user/auth.controllers.js
@@ -414,3 +414,29 @@ exports.logOut = async function (req, res) {
     return res.status(500).json({ message: "Server error, try again later!" });
   }
 };
+
+exports.updateNotificationPreferences = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const { resumeStatusUpdates, jobAlerts, internshipAlerts, blogUpdates, reminders } = req.body;
+    
+    const user = await User.findById(userId);
+    
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    user.notifications.resumeStatusUpdates = resumeStatusUpdates;
+    user.notifications.jobAlerts = jobAlerts;
+    user.notifications.internshipAlerts = internshipAlerts;
+    user.notifications.blogUpdates = blogUpdates;
+    user.notifications.reminders = reminders;
+
+    await user.save();
+
+    return res.status(200).json({ message: "Notification preferences updated successfully", user });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: "Server error, try again later" });
+  }
+};

--- a/models/user.model.js
+++ b/models/user.model.js
@@ -23,6 +23,28 @@ const userSchema = new mongoose.Schema({
         type: String,
         enum: ["Regular", "Google","Microsoft"],
         default: "Regular"
+    },
+    notifications: {
+        resumeStatusUpdates: {
+            type: Boolean,
+            default: true
+        },
+        jobAlerts: {
+            type: Boolean,
+            default: true
+        },
+        internshipAlerts: {
+            type: Boolean,
+            default: true
+        },
+        blogUpdates: {
+            type: Boolean,
+            default: true
+        },
+        reminders: {
+            type: Boolean,
+            default: true
+        }
     }
 }, {timestamps: true})
 

--- a/routes/user/auth.routes.js
+++ b/routes/user/auth.routes.js
@@ -13,5 +13,6 @@ router.post("/googleSignIn", auth.googleLogin);
 router.post("/verifyEmail", auth.verifyEmailAddress);
 router.delete("/logout", auth.logOut);
 router.delete("/removeEmail", auth.removeEmail);
+router.patch('/:userId/notifications', auth.updateNotificationPreferences);
 
 module.exports = router;


### PR DESCRIPTION
# Description
This pull request introduces an addition to the user schema by adding notification preferences. Additionally, it implements a new endpoint to manage these preferences.

## Changes Made

### 1. Schema Update:
   - Added a new nested object `notifications` to the user schema to store notification preferences as boolean values.
   - Included fields for `resumeStatusUpdates`, `jobAlerts`, `internshipAlerts`, `blogUpdates`, and `reminders`.
   - Defaulted all notification preferences to `true` for new users.

### 2. Controller Implementation
   - Added a new controller function `updateNotificationPreferences` to handle updating user notification preferences.
   - Implemented logic to find the user by ID, update the notification preferences based on the request body, and save the updated user.
   - Added error handling to handle cases such as user not found and server errors.

### 3. Routes Update
   - Created a new PATCH endpoint `/user/:userId/notifications` to handle updating notification preferences for a specific user.
   - Linked the new endpoint to the `updateNotificationPreferences` controller function.

## How  to Test

### 1. User Registration
   - Send a POST request to `http://localhost:3001/user/register` with the user's full name, email, and password in the request body.
   - Verify that the response indicates successful user creation.

### 2. Testing Notification Preferences Update
   - Send a PATCH request to `http://localhost:3001/user/:userId/notifications` with the user's ID in the URL and the notification preferences you want to update in the request body.
   - For example, to update `jobAlerts` to `false`, include the following JSON object in the body:
     ```json
     {
         "jobAlerts": false
     }
     ```
   - Verify that the response indicates successful update of notification preferences and includes the updated user object.

The testing medium used is Postman. 